### PR TITLE
Make the API know about JSON and Protocol Buffers.

### DIFF
--- a/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Factory.kt
+++ b/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Factory.kt
@@ -2,10 +2,8 @@
 
 package com.jakewharton.retrofit2.converter.kotlinx.serialization
 
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.Serializer.FromBytes
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.Serializer.FromString
-import kotlinx.serialization.KSerialLoader
-import kotlinx.serialization.KSerialSaver
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.Serializer.FromJson
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.Serializer.FromProtoBuf
 import kotlinx.serialization.serializerByTypeToken
 import okhttp3.MediaType
 import okhttp3.RequestBody
@@ -13,9 +11,6 @@ import okhttp3.ResponseBody
 import retrofit2.Converter
 import retrofit2.Retrofit
 import java.lang.reflect.Type
-
-typealias Loader<T> = (KSerialLoader<Any>, T) -> Any
-typealias Saver<T> = (KSerialSaver<Any>, Any) -> T
 
 internal class Factory(
     private val contentType: MediaType,
@@ -35,31 +30,27 @@ internal class Factory(
 }
 
 /**
- * Return a [Converter.Factory] which uses Kotlin serialization for string-based payloads.
+ * Return a [Converter.Factory] which uses Kotlin serialization for JSON-based payloads.
  *
  * Because Kotlin serialization is so flexible in the types it supports, this converter assumes
  * that it can handle all types. If you are mixing this with something else, you must add this
  * instance last to allow the other converters a chance to see their types.
  */
-fun stringBased(
-    contentType: MediaType,
-    loader: Loader<String>,
-    saver: Saver<String>
+fun jsonBased(
+    contentType: MediaType
 ): Converter.Factory {
-  return Factory(contentType, FromString(loader, saver))
+  return Factory(contentType, FromJson())
 }
 
 /**
- * Return a [Converter.Factory] which uses Kotlin serialization for byte-based payloads.
+ * Return a [Converter.Factory] which uses Kotlin serialization for Protocol-Buffers-based payloads.
  *
  * Because Kotlin serialization is so flexible in the types it supports, this converter assumes
  * that it can handle all types. If you are mixing this with something else, you must add this
  * instance last to allow the other converters a chance to see their types.
  */
-fun bytesBased(
-    contentType: MediaType,
-    loader: Loader<ByteArray>,
-    saver: Saver<ByteArray>
+fun protoBufBased(
+    contentType: MediaType
 ): Converter.Factory {
-  return Factory(contentType, FromBytes(loader, saver))
+  return Factory(contentType, FromProtoBuf())
 }

--- a/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KSerialLoaderConverter.kt
+++ b/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KSerialLoaderConverter.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.KSerialLoader
 import okhttp3.ResponseBody
 import retrofit2.Converter
 
-internal class KSerialLoaderConverter<T>(
+internal class KSerialLoaderConverter<T : Any>(
     private val loader: KSerialLoader<T>,
     private val serializer: Serializer
 ) : Converter<ResponseBody, T> {

--- a/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KSerialSaverConverter.kt
+++ b/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KSerialSaverConverter.kt
@@ -5,7 +5,7 @@ import okhttp3.MediaType
 import okhttp3.RequestBody
 import retrofit2.Converter
 
-internal class KSerialSaverConverter<T>(
+internal class KSerialSaverConverter<T : Any>(
     private val contentType: MediaType,
     private val saver: KSerialSaver<T>,
     private val serializer: Serializer

--- a/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Serializer.kt
+++ b/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Serializer.kt
@@ -2,41 +2,36 @@ package com.jakewharton.retrofit2.converter.kotlinx.serialization
 
 import kotlinx.serialization.KSerialLoader
 import kotlinx.serialization.KSerialSaver
+import kotlinx.serialization.json.JSON
+import kotlinx.serialization.protobuf.ProtoBuf
 import okhttp3.MediaType
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
 
-@Suppress("UNCHECKED_CAST") // Widening T to Any
 internal sealed class Serializer {
-  abstract fun <T> fromResponseBody(loader: KSerialLoader<T>, body: ResponseBody): T
-  abstract fun <T> toRequestBody(contentType: MediaType, saver: KSerialSaver<T>, value: T): RequestBody
+  abstract fun <T : Any> fromResponseBody(loader: KSerialLoader<T>, body: ResponseBody): T
+  abstract fun <T : Any> toRequestBody(contentType: MediaType, saver: KSerialSaver<T>, value: T): RequestBody
 
-  class FromString(
-      private val loader: Loader<String>,
-      private val saver: Saver<String>
-  ) : Serializer() {
-    override fun <T> fromResponseBody(loader: KSerialLoader<T>, body: ResponseBody): T {
+  class FromJson: Serializer() {
+    override fun <T : Any> fromResponseBody(loader: KSerialLoader<T>, body: ResponseBody): T {
       val string = body.string()
-      return loader(loader as KSerialLoader<Any>, string) as T
+      return JSON.parse(loader, string)
     }
 
-    override fun <T> toRequestBody(contentType: MediaType, saver: KSerialSaver<T>, value: T): RequestBody {
-      val string = saver(saver as KSerialSaver<Any>, value as Any)
+    override fun <T : Any> toRequestBody(contentType: MediaType, saver: KSerialSaver<T>, value: T): RequestBody {
+      val string = JSON.stringify(saver, value)
       return RequestBody.create(contentType, string)
     }
   }
 
-  class FromBytes(
-      private val loader: Loader<ByteArray>,
-      private val saver: Saver<ByteArray>
-  ): Serializer() {
-    override fun <T> fromResponseBody(loader: KSerialLoader<T>, body: ResponseBody): T {
+  class FromProtoBuf : Serializer() {
+    override fun <T : Any> fromResponseBody(loader: KSerialLoader<T>, body: ResponseBody): T {
       val bytes = body.bytes()
-      return loader(loader as KSerialLoader<Any>, bytes) as T
+      return ProtoBuf.load(loader, bytes)
     }
 
-    override fun <T> toRequestBody(contentType: MediaType, saver: KSerialSaver<T>, value: T): RequestBody {
-      val bytes = saver(saver as KSerialSaver<Any>, value as Any)
+    override fun <T : Any> toRequestBody(contentType: MediaType, saver: KSerialSaver<T>, value: T): RequestBody {
+      val bytes = ProtoBuf.dump(saver, value)
       return RequestBody.create(contentType, bytes)
     }
   }

--- a/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryBytesTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryBytesTest.kt
@@ -2,8 +2,6 @@ package com.jakewharton.retrofit2.converter.kotlinx.serialization
 
 import kotlinx.serialization.SerialId
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JSON
-import kotlinx.serialization.protobuf.ProtoBuf
 import okhttp3.MediaType
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -36,10 +34,9 @@ class KotlinSerializationConverterFactoryBytesTest {
 
   @Before fun setUp() {
     val contentType = MediaType.parse("application/x-protobuf")!!
-    val protobuf = ProtoBuf
     val retrofit = Retrofit.Builder()
         .baseUrl(server.url("/"))
-        .addConverterFactory(bytesBased(contentType, protobuf::load, protobuf::dump))
+        .addConverterFactory(protoBufBased(contentType))
         .build()
     service = retrofit.create(Service::class.java)
   }

--- a/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryStringTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryStringTest.kt
@@ -1,7 +1,6 @@
 package com.jakewharton.retrofit2.converter.kotlinx.serialization
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JSON
 import okhttp3.MediaType
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -30,10 +29,9 @@ class KotlinSerializationConverterFactoryStringTest {
 
   @Before fun setUp() {
     val contentType = MediaType.parse("application/json; charset=utf-8")!!
-    val json = JSON
     val retrofit = Retrofit.Builder()
         .baseUrl(server.url("/"))
-        .addConverterFactory(stringBased(contentType, json::parse, json::stringify))
+        .addConverterFactory(jsonBased(contentType))
         .build()
     service = retrofit.create(Service::class.java)
   }


### PR DESCRIPTION
instead of strings and byte arrays with users supplying the serializers.

feels simpler, though I may have misunderstood the purpose of the abstraction!