### PR TITLE
Update to Kotlin 1.3.70, kotlinx.serialization 0.20.0, retrofit 2.7.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ buildscript {
   ext.versions = [
     'kotlin': '1.3.70',
     'serializationRuntime': '0.20.0',
-    'retrofit': '2.7.2',
-    'okhttp': '3.12.10',
+    'retrofit': '2.6.4',
+    'okhttp': '3.14.7',
     'junit': '4.13',
     'truth': '1.0',
   ]

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 buildscript {
   ext.versions = [
-    'kotlin': '1.3.60'
+    'kotlin': '1.3.70',
+    'serializationRuntime': '0.20.0',
+    'retrofit': '2.7.2',
+    'okhttp': '3.12.10',
+    'junit': '4.13',
+    'truth': '1.0',
   ]
   repositories {
     mavenCentral()
@@ -25,11 +30,12 @@ repositories {
 }
 
 dependencies {
-  api 'com.squareup.retrofit2:retrofit:2.5.0'
+  api "com.squareup.retrofit2:retrofit:${versions.retrofit}"
   api "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-  api 'org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0'
+  api "org.jetbrains.kotlinx:kotlinx-serialization-runtime:${versions.serializationRuntime}"
 
-  testImplementation 'junit:junit:4.12'
-  testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
-  testImplementation 'com.google.truth:truth:0.42'
+  testImplementation "junit:junit:${versions.junit}"
+  testImplementation "com.squareup.okhttp3:mockwebserver:${versions.okhttp}"
+  testImplementation "com.google.truth:truth:${versions.truth}"
+  testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-protobuf:${versions.serializationRuntime}"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryBytesTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryBytesTest.kt
@@ -1,6 +1,6 @@
 package com.jakewharton.retrofit2.converter.kotlinx.serialization
 
-import kotlinx.serialization.SerialId
+import kotlinx.serialization.protobuf.ProtoId
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoBuf
 import okhttp3.MediaType
@@ -31,7 +31,7 @@ class KotlinSerializationConverterFactoryBytesTest {
   }
 
   @Serializable
-  data class User(@SerialId(1) val name: String)
+  data class User(@ProtoId(1) val name: String)
 
   @Before fun setUp() {
     val contentType = MediaType.get("application/x-protobuf")

--- a/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryStringTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryStringTest.kt
@@ -1,6 +1,7 @@
 package com.jakewharton.retrofit2.converter.kotlinx.serialization
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType
 import okhttp3.mockwebserver.MockResponse
@@ -28,6 +29,7 @@ class KotlinSerializationConverterFactoryStringTest {
   @Serializable
   data class User(val name: String)
 
+  @UnstableDefault
   @Before fun setUp() {
     val contentType = MediaType.get("application/json; charset=utf-8")
     val retrofit = Retrofit.Builder()


### PR DESCRIPTION
Fixes #16.

PR updates kotlin and kotlinx.serialization along with other dependencies:

- kotlin: 1.3.70
- kotlinx serialization runtime: 0.20.0
- retrofit: ~~2.7.2~~ 2.6.4
- okhttp: 3.14.7
- junit: 4.13
- truth: 1.0
- gradle: 6.2.2

Also fixed test by adding the new `kotlinx-serialization-protobuf` artifact.