### PR TITLE
Respect Factory contract of returning null when unable to serialize

### DIFF
--- a/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Factory.kt
+++ b/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Factory.kt
@@ -20,13 +20,21 @@ internal class Factory(
 ): Converter.Factory() {
   override fun responseBodyConverter(type: Type, annotations: Array<out Annotation>,
       retrofit: Retrofit): Converter<ResponseBody, *>? {
-    val loader = serializerByTypeToken(type)
+    val loader = try {
+      serializerByTypeToken(type)
+    } catch (e: Exception) {
+      return null
+    }
     return DeserializationStrategyConverter(loader, serializer)
   }
 
   override fun requestBodyConverter(type: Type, parameterAnnotations: Array<out Annotation>,
       methodAnnotations: Array<out Annotation>, retrofit: Retrofit): Converter<*, RequestBody>? {
-    val saver = serializerByTypeToken(type)
+    val saver = try {
+      serializerByTypeToken(type)
+    } catch (e: Exception) {
+      return null
+    }
     return SerializationStrategyConverter(contentType, saver, serializer)
   }
 }


### PR DESCRIPTION
The `Converter.Factory` contract specifies returning `null` when `type` cannot be handled by the factory. Currently the code calls into kotlinx.serialization, and `serializerByTypeToken` throws an exception. Instead it the Factory should catch the exception and return null