### PR TITLE
Use contextual serializers, add tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{kt,kts}]
+kotlin_imports_layout=ascii

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
     classpath "org.jetbrains.kotlin:kotlin-serialization:${versions.kotlin}"
+    classpath 'com.diffplug.spotless:spotless-plugin-gradle:5.1.0'
   }
 }
 
@@ -52,5 +53,16 @@ compileTestKotlin {
     freeCompilerArgs += [
         '-Xopt-in=kotlinx.serialization.ExperimentalSerializationApi',
     ]
+  }
+}
+
+apply plugin: 'com.diffplug.spotless'
+spotless {
+  kotlin {
+    ktlint('0.37.2').userData([
+        // TODO this should all come from editorconfig https://github.com/diffplug/spotless/issues/142
+        'indent_size': '2',
+        'kotlin_imports_layout': 'ascii',
+    ])
   }
 }

--- a/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/DeserializationStrategyConverter.kt
+++ b/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/DeserializationStrategyConverter.kt
@@ -5,8 +5,8 @@ import okhttp3.ResponseBody
 import retrofit2.Converter
 
 internal class DeserializationStrategyConverter<T>(
-    private val loader: DeserializationStrategy<T>,
-    private val serializer: Serializer
+  private val loader: DeserializationStrategy<T>,
+  private val serializer: Serializer
 ) : Converter<ResponseBody, T> {
   override fun convert(value: ResponseBody) = serializer.fromResponseBody(loader, value)
 }

--- a/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Factory.kt
+++ b/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Factory.kt
@@ -4,6 +4,7 @@ package com.jakewharton.retrofit2.converter.kotlinx.serialization
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.Serializer.FromBytes
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.Serializer.FromString
+import java.lang.reflect.Type
 import kotlinx.serialization.BinaryFormat
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.StringFormat
@@ -12,21 +13,27 @@ import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Converter
 import retrofit2.Retrofit
-import java.lang.reflect.Type
 
 @ExperimentalSerializationApi
 internal class Factory(
-    private val contentType: MediaType,
-    private val serializer: Serializer
-): Converter.Factory() {
-  override fun responseBodyConverter(type: Type, annotations: Array<out Annotation>,
-      retrofit: Retrofit): Converter<ResponseBody, *>? {
+  private val contentType: MediaType,
+  private val serializer: Serializer
+) : Converter.Factory() {
+  override fun responseBodyConverter(
+    type: Type,
+    annotations: Array<out Annotation>,
+    retrofit: Retrofit
+  ): Converter<ResponseBody, *>? {
     val loader = serializer.serializer(type)
     return DeserializationStrategyConverter(loader, serializer)
   }
 
-  override fun requestBodyConverter(type: Type, parameterAnnotations: Array<out Annotation>,
-      methodAnnotations: Array<out Annotation>, retrofit: Retrofit): Converter<*, RequestBody>? {
+  override fun requestBodyConverter(
+    type: Type,
+    parameterAnnotations: Array<out Annotation>,
+    methodAnnotations: Array<out Annotation>,
+    retrofit: Retrofit
+  ): Converter<*, RequestBody>? {
     val saver = serializer.serializer(type)
     return SerializationStrategyConverter(contentType, saver, serializer)
   }

--- a/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Factory.kt
+++ b/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Factory.kt
@@ -7,7 +7,6 @@ import com.jakewharton.retrofit2.converter.kotlinx.serialization.Serializer.From
 import kotlinx.serialization.BinaryFormat
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.StringFormat
-import kotlinx.serialization.serializer
 import okhttp3.MediaType
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
@@ -22,13 +21,13 @@ internal class Factory(
 ): Converter.Factory() {
   override fun responseBodyConverter(type: Type, annotations: Array<out Annotation>,
       retrofit: Retrofit): Converter<ResponseBody, *>? {
-    val loader = serializer(type)
+    val loader = serializer.serializer(type)
     return DeserializationStrategyConverter(loader, serializer)
   }
 
   override fun requestBodyConverter(type: Type, parameterAnnotations: Array<out Annotation>,
       methodAnnotations: Array<out Annotation>, retrofit: Retrofit): Converter<*, RequestBody>? {
-    val saver = serializer(type)
+    val saver = serializer.serializer(type)
     return SerializationStrategyConverter(contentType, saver, serializer)
   }
 }

--- a/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/SerializationStrategyConverter.kt
+++ b/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/SerializationStrategyConverter.kt
@@ -6,9 +6,9 @@ import okhttp3.RequestBody
 import retrofit2.Converter
 
 internal class SerializationStrategyConverter<T>(
-    private val contentType: MediaType,
-    private val saver: SerializationStrategy<T>,
-    private val serializer: Serializer
+  private val contentType: MediaType,
+  private val saver: SerializationStrategy<T>,
+  private val serializer: Serializer
 ) : Converter<T, RequestBody> {
   override fun convert(value: T) = serializer.toRequestBody(contentType, saver, value)
 }

--- a/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Serializer.kt
+++ b/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Serializer.kt
@@ -3,18 +3,27 @@ package com.jakewharton.retrofit2.converter.kotlinx.serialization
 import kotlinx.serialization.BinaryFormat
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialFormat
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.StringFormat
+import kotlinx.serialization.serializer
 import okhttp3.MediaType
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
+import java.lang.reflect.Type
 
+@OptIn(ExperimentalSerializationApi::class)
 internal sealed class Serializer {
   abstract fun <T> fromResponseBody(loader: DeserializationStrategy<T>, body: ResponseBody): T
   abstract fun <T> toRequestBody(contentType: MediaType, saver: SerializationStrategy<T>, value: T): RequestBody
+  protected abstract val format: SerialFormat
+
+  fun serializer(type: Type): KSerializer<Any> = format.serializersModule.serializer(type)
+
 
   @OptIn(ExperimentalSerializationApi::class) // Experimental is only for subtypes.
-  class FromString(private val format: StringFormat) : Serializer() {
+  class FromString(override val format: StringFormat) : Serializer() {
     override fun <T> fromResponseBody(loader: DeserializationStrategy<T>, body: ResponseBody): T {
       val string = body.string()
       return format.decodeFromString(loader, string)
@@ -27,7 +36,7 @@ internal sealed class Serializer {
   }
 
   @OptIn(ExperimentalSerializationApi::class) // Experimental is only for subtypes.
-  class FromBytes(private val format: BinaryFormat): Serializer() {
+  class FromBytes(override val format: BinaryFormat): Serializer() {
     override fun <T> fromResponseBody(loader: DeserializationStrategy<T>, body: ResponseBody): T {
       val bytes = body.bytes()
       return format.decodeFromByteArray(loader, bytes)

--- a/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Serializer.kt
+++ b/src/main/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/Serializer.kt
@@ -1,5 +1,6 @@
 package com.jakewharton.retrofit2.converter.kotlinx.serialization
 
+import java.lang.reflect.Type
 import kotlinx.serialization.BinaryFormat
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -11,7 +12,6 @@ import kotlinx.serialization.serializer
 import okhttp3.MediaType
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
-import java.lang.reflect.Type
 
 @OptIn(ExperimentalSerializationApi::class)
 internal sealed class Serializer {
@@ -20,7 +20,6 @@ internal sealed class Serializer {
   protected abstract val format: SerialFormat
 
   fun serializer(type: Type): KSerializer<Any> = format.serializersModule.serializer(type)
-
 
   @OptIn(ExperimentalSerializationApi::class) // Experimental is only for subtypes.
   class FromString(override val format: StringFormat) : Serializer() {
@@ -36,7 +35,7 @@ internal sealed class Serializer {
   }
 
   @OptIn(ExperimentalSerializationApi::class) // Experimental is only for subtypes.
-  class FromBytes(override val format: BinaryFormat): Serializer() {
+  class FromBytes(override val format: BinaryFormat) : Serializer() {
     override fun <T> fromResponseBody(loader: DeserializationStrategy<T>, body: ResponseBody): T {
       val bytes = body.bytes()
       return format.decodeFromByteArray(loader, bytes)

--- a/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryBytesTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryBytesTest.kt
@@ -36,9 +36,9 @@ class KotlinSerializationConverterFactoryBytesTest {
   @Before fun setUp() {
     val contentType = MediaType.get("application/x-protobuf")
     val retrofit = Retrofit.Builder()
-        .baseUrl(server.url("/"))
-        .addConverterFactory(ProtoBuf.asConverterFactory(contentType))
-        .build()
+      .baseUrl(server.url("/"))
+      .addConverterFactory(ProtoBuf.asConverterFactory(contentType))
+      .build()
     service = retrofit.create(Service::class.java)
   }
 

--- a/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryStringTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinSerializationConverterFactoryStringTest.kt
@@ -31,9 +31,9 @@ class KotlinSerializationConverterFactoryStringTest {
   @Before fun setUp() {
     val contentType = MediaType.get("application/json; charset=utf-8")
     val retrofit = Retrofit.Builder()
-        .baseUrl(server.url("/"))
-        .addConverterFactory(Json.asConverterFactory(contentType))
-        .build()
+      .baseUrl(server.url("/"))
+      .addConverterFactory(Json.asConverterFactory(contentType))
+      .build()
     service = retrofit.create(Service::class.java)
   }
 

--- a/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinxSerializationConverterFactoryContextualListTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinxSerializationConverterFactoryContextualListTest.kt
@@ -1,0 +1,84 @@
+package com.jakewharton.retrofit2.converter.kotlinx.serialization
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+import okhttp3.MediaType
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+class KotlinxSerializationConverterFactoryContextualListTest {
+  @get:Rule
+  val server = MockWebServer()
+
+  private lateinit var service: Service
+
+  interface Service {
+    @GET("/")
+    fun deserialize(): Call<List<User>>
+
+    @POST("/")
+    fun serialize(@Body users: List<User>): Call<Void?>
+  }
+
+  data class User(val name: String)
+
+  object UserSerializer : KSerializer<User> {
+    override val descriptor = PrimitiveSerialDescriptor("User", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): User =
+      decoder.decodeSerializableValue(UserResponse.serializer()).run {
+        User(name)
+      }
+
+    override fun serialize(encoder: Encoder, value: User): Unit =
+      encoder.encodeSerializableValue(UserResponse.serializer(), UserResponse(value.name))
+
+    @Serializable
+    private data class UserResponse(val name: String)
+  }
+
+  @Before
+  fun setUp() {
+    val module = SerializersModule {
+      contextual(UserSerializer)
+    }
+    val contentType = MediaType.get("application/json; charset=utf-8")
+    val retrofit = Retrofit.Builder()
+      .baseUrl(server.url("/"))
+      .addConverterFactory(Json { serializersModule = module }.asConverterFactory(contentType))
+      .build()
+    service = retrofit.create(Service::class.java)
+  }
+
+  @Test
+  fun deserialize() {
+    server.enqueue(MockResponse().setBody("""[{"name":"Bob"}]"""))
+    val user = service.deserialize().execute().body()!!
+    assertEquals(listOf(User("Bob")), user)
+  }
+
+  @Test
+  fun serialize() {
+    server.enqueue(MockResponse())
+    service.serialize(listOf(User("Bob"))).execute()
+    val request = server.takeRequest()
+    assertEquals("""[{"name":"Bob"}]""", request.body.readUtf8())
+    assertEquals("application/json; charset=utf-8", request.headers["Content-Type"])
+  }
+}

--- a/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinxSerializationConverterFactoryContextualTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/converter/kotlinx/serialization/KotlinxSerializationConverterFactoryContextualTest.kt
@@ -1,0 +1,84 @@
+package com.jakewharton.retrofit2.converter.kotlinx.serialization
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+import okhttp3.MediaType
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+class KotlinxSerializationConverterFactoryContextualTest {
+  @get:Rule
+  val server = MockWebServer()
+
+  private lateinit var service: Service
+
+  interface Service {
+    @GET("/")
+    fun deserialize(): Call<User>
+
+    @POST("/")
+    fun serialize(@Body user: User): Call<Void?>
+  }
+
+  data class User(val name: String)
+
+  object UserSerializer : KSerializer<User> {
+    override val descriptor = PrimitiveSerialDescriptor("User", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): User =
+      decoder.decodeSerializableValue(UserResponse.serializer()).run {
+        User(name)
+      }
+
+    override fun serialize(encoder: Encoder, value: User): Unit =
+      encoder.encodeSerializableValue(UserResponse.serializer(), UserResponse(value.name))
+
+    @Serializable
+    private data class UserResponse(val name: String)
+  }
+
+  @Before
+  fun setUp() {
+    val module = SerializersModule {
+      contextual(UserSerializer)
+    }
+    val contentType = MediaType.get("application/json; charset=utf-8")
+    val retrofit = Retrofit.Builder()
+      .baseUrl(server.url("/"))
+      .addConverterFactory(Json { serializersModule = module }.asConverterFactory(contentType))
+      .build()
+    service = retrofit.create(Service::class.java)
+  }
+
+  @Test
+  fun deserialize() {
+    server.enqueue(MockResponse().setBody("""{"name":"Bob"}"""))
+    val user = service.deserialize().execute().body()!!
+    assertEquals(User("Bob"), user)
+  }
+
+  @Test
+  fun serialize() {
+    server.enqueue(MockResponse())
+    service.serialize(User("Bob")).execute()
+    val request = server.takeRequest()
+    assertEquals("""{"name":"Bob"}""", request.body.readUtf8())
+    assertEquals("application/json; charset=utf-8", request.headers["Content-Type"])
+  }
+}


### PR DESCRIPTION
This PR fixes #18 and adds two tests--one that tests the provided broken example in the issue, and one that checks an additional edge case with collections of types that have registered contextual serializers.